### PR TITLE
launchファイルの整備

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,16 +61,39 @@ ament_target_dependencies(pick_and_move_tf
     rclcpp
     tf2_geometry_msgs
 )
-
 add_executable(fixed_position_publisher
   src/fixed_position_publisher.cpp
 )
-
 ament_target_dependencies(fixed_position_publisher
     rclcpp
     geometry_msgs
     tf2_ros
 )
+add_executable(press_the_stamp
+  src/press_the_stamp.cpp
+)
+ament_target_dependencies(press_the_stamp
+    cv_bridge
+    geometry_msgs
+    image_geometry
+    moveit_ros_planning_interface
+    OpenCV
+    rclcpp
+    tf2_geometry_msgs
+)
+add_executable(press_the_stamp_tf
+  src/press_the_stamp_tf.cpp
+)
+ament_target_dependencies(press_the_stamp_tf
+    cv_bridge
+    geometry_msgs
+    image_geometry
+    moveit_ros_planning_interface
+    OpenCV
+    rclcpp
+    tf2_geometry_msgs
+)
+
 
 # src下のソースコードはTARGETSで
 # launch下のlaunchファイルはDIRECTORYで
@@ -88,6 +111,14 @@ install(TARGETS
 )
 install(TARGETS
   fixed_position_publisher
+  DESTINATION lib/${PROJECT_NAME}/
+)
+install(TARGETS
+  press_the_stamp
+  DESTINATION lib/${PROJECT_NAME}/
+)
+install(TARGETS
+  press_the_stamp_tf
   DESTINATION lib/${PROJECT_NAME}/
 )
 install(DIRECTORY

--- a/launch/mock_pick_and_move_tf.launch.py
+++ b/launch/mock_pick_and_move_tf.launch.py
@@ -2,7 +2,9 @@
 # Copyright 2024 Akira Matsumoto
 # SPDX-License-Identifier: Apache 2.0
 # このファイルはKeitaro Nakamuraによって作成されたcamera_picking.launch.pyをコピーし, 一部を改変したものです.
-# もとのファイルでcolor_detection.cppだった部分が, fixed_position_publisher.cppとなっています.
+# 変更内容
+#   color_detection : fixed_position_publisher
+#   crane_x7_simple_example : crane_x7_stamp
 
 import os
 
@@ -55,15 +57,15 @@ def generate_launch_description():
     )
     # アームの動きのコードを起動するのはこっち
     picking_node = Node(# name="pick_and_move_tf",
-                        package='crane_x7_simple_examples',
+                        package='crane_x7_stamp',
                         executable='pick_and_move_tf',
                         output='screen',
                         parameters=[{'robot_description': description_loader.load()},
                                     robot_description_semantic,
                                     kinematics_yaml])
-    # 画像処理のコードを起動するのはこっち
+    # 固定座標を送るコードを起動するのはこっち
     detection_node = Node(# name='fixed_position_publisher'
-                          package='crane_x7_simple_examples',
+                          package='crane_x7_stamp',
                           executable='fixed_position_publisher',
                           output='screen')
 

--- a/launch/mock_press_the_stamp_tf.launch.py
+++ b/launch/mock_press_the_stamp_tf.launch.py
@@ -1,8 +1,11 @@
 # Copyright 2023 Keitaro Nakamura
+# Copyright 2024 Akira Matsumoto
 # SPDX-License-Identifier: Apache 2.0
-# このファイルはKeitaro Nakamuraによって作成され, その後Akira Matsumotoによって変更が加えられました
+# このファイルはKeitaro Nakamuraによって作成されたcamera_picking.launch.pyをコピーし, 一部を改変したものです.
 # 変更内容
+#   color_detection : fixed_position_publisher
 #   crane_x7_simple_example : crane_x7_stamp
+#   pick_and_move_tf : press_the_stamp_tf
 
 import os
 
@@ -56,15 +59,15 @@ def generate_launch_description():
     # アームの動きのコードを起動するのはこっち
     picking_node = Node(# name="pick_and_move_tf",
                         package='crane_x7_stamp',
-                        executable='pick_and_move_tf',
+                        executable='press_the_stamp_tf',
                         output='screen',
                         parameters=[{'robot_description': description_loader.load()},
                                     robot_description_semantic,
                                     kinematics_yaml])
-    # 画像処理のコードを起動するのはこっち
-    detection_node = Node(# name='color_detection'
+    # 固定座標を送るコードを起動するのはこっち
+    detection_node = Node(# name='fixed_position_publisher'
                           package='crane_x7_stamp',
-                          executable='color_detection',
+                          executable='fixed_position_publisher',
                           output='screen')
 
     return LaunchDescription([

--- a/launch/pick_and_move.launch.py
+++ b/launch/pick_and_move.launch.py
@@ -1,5 +1,9 @@
 # SPDX-FileCopyrightText: 2023 Keitaro Nakamura
 # SPDX-License-Identifier: Apache 2.0
+# このファイルはKeitaro Nakamuraによって作成され, その後Akira Matsumotoによって変更が加えられました
+# 変更内容
+#   crane_x7_simple_example : crane_x7_stamp
+
 import os
 
 from ament_index_python.packages import get_package_share_directory
@@ -51,7 +55,7 @@ def generate_launch_description():
     )
     #パッケージ名の変更、実行するコードの変更は以下を編集してください
     example_node = Node(
-                        package='crane_x7_simple_examples',
+                        package='crane_x7_stamp',
                         executable='pick_and_move',
                         output='screen',
                         parameters=[{'robot_description': description_loader.load()},

--- a/src/fixed_position_publisher.cpp
+++ b/src/fixed_position_publisher.cpp
@@ -16,12 +16,7 @@ public:
   FixedPositionPublisher()
   : Node("fixed_position_publisher")
   {
- 
     tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*this);
-
-    timer_ = this->create_wall_timer(
-      std::chrono::seconds(1),
-      std::bind(&FixedPositionPublisher::send_fixed_transform, this));
   }
 
 private:
@@ -31,8 +26,6 @@ private:
   void send_fixed_transform()
   {
     geometry_msgs::msg::TransformStamped t;
-    t.header.stamp = this->get_clock()->now();  
-    t.header.frame_id = "world"; 
     t.child_frame_id = "target_0";  
 
     // 固定座標を設定
@@ -41,8 +34,6 @@ private:
     t.transform.translation.z = 0.2;
 
     tf_broadcaster_->sendTransform(t);
-
-    RCLCPP_INFO(this->get_logger(), "固定座標: [0.5, 0.0, 0.05]");
   }
 };
 

--- a/src/fixed_position_publisher.cpp
+++ b/src/fixed_position_publisher.cpp
@@ -37,14 +37,8 @@ private:
 
     // 固定座標を設定
     t.transform.translation.x = 0.5;
-    t.transform.translation.y = 0.0;
-    t.transform.translation.z = 0.05;
-
-    // ここ後で消してもいいかも
-    t.transform.rotation.x = 0.0;
-    t.transform.rotation.y = 0.0;
-    t.transform.rotation.z = 0.0;
-    t.transform.rotation.w = 1.0;
+    t.transform.translation.y = 0.4;
+    t.transform.translation.z = 0.2;
 
     tf_broadcaster_->sendTransform(t);
 


### PR DESCRIPTION
- 以下の3つのファイルのpackage名を修正しました（crane_x7_simple_example : crane_x7_stamp）.
    - launch/camera_picking.launch.py
    - launch/mock_pick_and_move_tf.launch.py
    - launch/pick_and_move.launch.py
- 以下のファイルを新規作成しました.
    - launch/mock_press_the_stamp_tf.launch.py
        - このファイルによって実行されるノードは以下の2つです.
            - pick_and_move_tfノード
            - fixed_position_publisher_ノード
        - このファイルを実行すると, 自動的に指定した座標までマニピュレータの手先が移動しハンコを押します.